### PR TITLE
Fix: Filename display

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,3 +28,4 @@ Contains information about the versions of Termsequel
         | Where support | [ISSUE](https://github.com/sgtcortez/Termsequel/issues/14) | [PR](https://github.com/sgtcortez/Termsequel/pull/26) | Add support for where filters |  
         | Level column | [ISSUE](https://github.com/sgtcortez/Termsequel/issues/13) | [PR](https://github.com/sgtcortez/Termsequel/pull/28) |
         | File type column | [ISSUE](https://github.com/sgtcortez/Termsequel/issues/9) | [PR](https://github.com/sgtcortez/Termsequel/pull/30) | Add the file type column |
+        | Filename column display | [ISSUE](https://github.com/sgtcortez/Termsequel/issues/34) | [PR](https://github.com/sgtcortez/Termsequel/pull/38) | The file name column, is displayed with the relative path |

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -229,7 +229,11 @@ static std::vector<struct StatResult *> * get_information(
 
    // Store the stat result in the heap
    auto stat_value = new struct StatResult;
-   stat_value->filename = name;
+   if (name.find_first_of("/") != std::string::npos){
+      stat_value->filename = name.substr(name.find_last_of("/") + 1);
+   } else {
+      stat_value->filename = name;
+   }
    stat_value->size = stat_buffer.st_size;
    stat_value->owner = get_owner_name(stat_buffer.st_uid);
    stat_value->level = max_level;


### PR DESCRIPTION
Closes #34 

When showing the filename, displays just the name, not the relative path anymore.