### PR TITLE
Feat: Add support to negate columns #40

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -52,4 +52,4 @@ Contains information about the versions of Termsequel
         | Feature | Issue | Pull Request | Description |
         | :-:   | :-: | :-: | :-: |
         | Add LAST_MODIFICATION column | [ISSUE](https://github.com/sgtcortez/Termsequel/issues/32) | [PR](https://github.com/sgtcortez/Termsequel/pull/47) | Add the last modification date of a file |
-
+        | Support for negate expressions | [ISSUE](https://github.com/sgtcortez/Termsequel/issues/40) | [PR]() | Add three new operators, to be used as the negate form |

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ $ termsequel 'SELECT NAME FROM /HOME'
         -- Returns the files that the owner has the read and execute flag set.
         ```
 
+        It is possible to negate operators too!    
+        Actually, we are not negating operators, **Termsequel 1.1** introduced new operators(NOT_CONTAINS, NOT_STARTS_WITH and NOT_ENDS_WITH).   
+        For examples, you want to select all the files that do not end with `.txt`.   
+        ```sql
+        SELECT NAME FROM . WHERE NAME NOT_ENDS_WITH .txt
+        ```
 
 
 

--- a/include/system.hpp
+++ b/include/system.hpp
@@ -36,8 +36,11 @@ namespace Termsequel {
    enum class Operator {
       EQUAL,
       STARTS_WITH,
+      NOT_STARTS_WITH,
       ENDS_WITH,
+      NOT_ENDS_WITH,
       CONTAINS,
+      NOT_CONTAINS,
       BIGGER,
       LESS,
       BIGGER_OR_EQUAL,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -83,8 +83,11 @@ namespace Termsequel {
          static const Token END;
          static const Token EQUAL;
          static const Token STARTS_WITH;
+         static const Token NOT_STARTS_WITH;
          static const Token ENDS_WITH;
+         static const Token NOT_ENDS_WITH;
          static const Token CONTAINS;
+         static const Token NOT_CONTAINS;
          static const Token BIGGER;
          static const Token LESS;
          static const Token BIGGER_OR_EQUAL;
@@ -154,12 +157,15 @@ namespace Termsequel {
    Token const Token::END                = (TokenType::TYPE_END);
    Token const Token::EQUAL              = (TokenType::TYPE_COMPARASION);
    Token const Token::STARTS_WITH        = (TokenType::TYPE_COMPARASION);
+   Token const Token::NOT_STARTS_WITH    = (TokenType::TYPE_COMPARASION);
    Token const Token::ENDS_WITH          = (TokenType::TYPE_COMPARASION);
+   Token const Token::NOT_ENDS_WITH      = (TokenType::TYPE_COMPARASION);
+   Token const Token::CONTAINS           = (TokenType::TYPE_COMPARASION);
+   Token const Token::NOT_CONTAINS       = (TokenType::TYPE_COMPARASION);
    Token const Token::BIGGER             = (TokenType::TYPE_COMPARASION);
    Token const Token::LESS               = (TokenType::TYPE_COMPARASION);
    Token const Token::BIGGER_OR_EQUAL    = (TokenType::TYPE_COMPARASION);
    Token const Token::LESS_OR_EQUAL      = (TokenType::TYPE_COMPARASION);
-   Token const Token::CONTAINS           = (TokenType::TYPE_COMPARASION);
    Token const Token::AND                = (TokenType::TYPE_LOGICAL);
    Token const Token::OR                 = (TokenType::TYPE_LOGICAL);
 
@@ -229,10 +235,16 @@ namespace Termsequel {
                return new Lexeme ( Token::OR );
             } else if ( string.compare("STARTS_WITH") == 0 ) {
                return new Lexeme (Token::STARTS_WITH);
+            } else if ( string.compare("NOT_STARTS_WITH") == 0 ) {
+               return new Lexeme (Token::NOT_STARTS_WITH);
             } else if ( string.compare("ENDS_WITH") == 0 ) {
                return new Lexeme( Token::ENDS_WITH);
+            } else if ( string.compare("NOT_ENDS_WITH") == 0 ) {
+               return new Lexeme( Token::NOT_ENDS_WITH);
             } else if ( string.compare("CONTAINS") == 0 ) {
                return new Lexeme (Token::CONTAINS);
+            } else if ( string.compare("NOT_CONTAINS") == 0 ) {
+               return new Lexeme (Token::NOT_CONTAINS);
             } else if ( string.compare(">") == 0) {
                return new Lexeme (Token::BIGGER);
             } else if ( string.compare("<") == 0 ) {
@@ -429,10 +441,16 @@ void Termsequel::Compiler::execute() {
                current_condition->operator_value = Operator::EQUAL;
             } else if ( Token::STARTS_WITH == *(token)) {
                current_condition->operator_value = Operator::STARTS_WITH;
+            } else if ( Token::NOT_STARTS_WITH == *(token)) {
+               current_condition->operator_value = Operator::NOT_STARTS_WITH;
             } else if ( Token::ENDS_WITH == *(token) ) {
                current_condition->operator_value = Operator::ENDS_WITH;
+            } else if ( Token::NOT_ENDS_WITH == *(token) ) {
+               current_condition->operator_value = Operator::NOT_ENDS_WITH;
             } else if (Token::CONTAINS == *(token)) {
                current_condition->operator_value = Operator::CONTAINS;
+            } else if (Token::NOT_CONTAINS == *(token)) {
+               current_condition->operator_value = Operator::NOT_CONTAINS;
             } else if (Token::BIGGER == *(token)) {
                current_condition->operator_value = Operator::BIGGER;
             } else if (Token::LESS == *(token)) {

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -575,6 +575,23 @@ static bool should_return(struct StatResult *row,
           current = false;
         }
         break;
+      case Termsequel::Operator::NOT_STARTS_WITH:
+        if (compare_string) {
+          if (condition->value.size() > strlen(compare_value.string_value)) {
+            current = false;
+          } else {
+            current = std::strncmp(
+               compare_value.string_value,
+               condition->value.c_str(),
+               condition->value.size()
+            ) != 0;
+          }
+        } else {
+          // tries to compare integer with starts with
+          // should throw invalid syntax, but, this will not be so easy
+          current = false;
+        }
+        break;
       case Termsequel::Operator::ENDS_WITH:
         if (compare_string) {
           if (condition->value.size() > strlen(compare_value.string_value)) {
@@ -591,6 +608,20 @@ static bool should_return(struct StatResult *row,
           current = false;
         }
         break;
+      case Termsequel::Operator::NOT_ENDS_WITH:
+        if (compare_string) {
+          if (condition->value.size() > strlen(compare_value.string_value)) {
+            current = false;
+          } else {
+            std::string tmp = compare_value.string_value;
+            current = tmp.compare(tmp.size() - condition->value.size(), condition->value.size(), condition->value) != 0;
+          }
+        } else {
+          // tries to compare integer with starts with
+          // should throw invalid syntax, but, this will not be so easy to do
+          current = false;
+        }
+        break;
       case Termsequel::Operator::CONTAINS:
         if (compare_string) {
           if (condition->value.size() > strlen(compare_value.string_value)) {
@@ -598,6 +629,19 @@ static bool should_return(struct StatResult *row,
           } else {
             current = std::strstr(compare_value.string_value,
                                   condition->value.c_str()) != nullptr;
+          }
+        } else {
+          // tries to compare integer with starts with
+          // should throw invalid syntax, but, this will not be so easy
+          current = false;
+        }
+        break;
+      case Termsequel::Operator::NOT_CONTAINS:
+        if (compare_string) {
+          if (condition->value.size() > strlen(compare_value.string_value)) {
+            current = false;
+          } else {
+            current = std::strstr(compare_value.string_value, condition->value.c_str()) == nullptr;
           }
         } else {
           // tries to compare integer with starts with


### PR DESCRIPTION
Closes: #40 .   

Add three new operators to act as the negate form of **CONTAIS**, **STARTS_WITH** and **ENDS_WITH**.

**Table operators and its negate form:**          
| OPERATOR | NEGATE | 
| :-:      | :-: |
| >        | <= |
| >=       | < |
| =        | != |
| CONTAINS | NOT_CONTAINS |
| STARTS_WITH | NOT_STARTS_WITH |
| ENDS_WITH | NOT_ENDS_WITH |


# Task list
This pull request is well tested, and does not break the current code.   
- [x] Works on both operating system.   
- [x] Is well tested.   
- [x] Is documented. Readme, Changelog, binary help output and etc ...

# Description of the feature
- [x] Is backward compatible?
- [x] Is the commit history well described? 
